### PR TITLE
Add extra FATAL Output for additional logo (site_logo.gif)

### DIFF
--- a/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
+++ b/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
@@ -202,7 +202,7 @@ class FileListValidator
 					$this->output->addMessage($level, 'Found additional file', $origin_file);
 				}
 
-				if (substr($origin_file, -13 ) === 'site_logo.gif' || substr($origin_file, -14 ) === '/site_logo.gif')
+				if (substr($origin_file, -14) === '/site_logo.gif')
 				{
 					$this->output->addMessage(Output::FATAL, 'Found additional file', $origin_file);
 				}

--- a/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
+++ b/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
@@ -201,6 +201,11 @@ class FileListValidator
 					}
 					$this->output->addMessage($level, 'Found additional file', $origin_file);
 				}
+
+				if (substr($origin_file, -13 ) === 'site_logo.gif' || substr($origin_file, -14 ) === '/site_logo.gif')
+				{
+					$this->output->addMessage(Output::FATAL, 'Found additional file', $origin_file);
+				}
 			}
 		}
 


### PR DESCRIPTION
For #36 

With an additional site_logo.gif this will lead to an double output of 
```
 Fatal in styles/prosilver/theme/images/site_logo.gif:
Found additional file

 Fatal in styles/prosilver/theme/images/site_logo.gif:
Found additional file2
```

@DavidIQ: Is it that what you have missed? 