### PR TITLE
More lenient validation rules for RTL languages

### DIFF
--- a/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
+++ b/src/Phpbb/TranslationValidator/Validator/FileListValidator.php
@@ -16,6 +16,8 @@ use Phpbb\TranslationValidator\Output\OutputInterface;
 class FileListValidator
 {
 	/** @var string */
+	protected $direction = 'ltr';
+	/** @var string */
 	protected $originIso;
 	/** @var string */
 	protected $originPath;
@@ -147,9 +149,9 @@ class FileListValidator
 			include($filePath);
 		}
 
-		$direction = $lang['DIRECTION'];
+		$this->direction = $lang['DIRECTION'];
 		// Throw error, if invalid direction is used
-		if (!in_array($direction, array('rtl', 'ltr')))
+		if (!in_array($this->direction, array('rtl', 'ltr')))
 		{
 			$this->output->addMessage(Output::FATAL, 'DIRECTION needs to be rtl or ltr');
 		}
@@ -195,7 +197,7 @@ class FileListValidator
 					{
 						$level = Output::FATAL;
 					}
-					else if (in_array(substr($origin_file, -4), array('.gif', '.png')) && $direction === 'rtl')
+					else if (in_array(substr($origin_file, -4), array('.gif', '.png')) && $this->direction === 'rtl')
 					{
 						$level = Output::WARNING;
 					}
@@ -245,5 +247,14 @@ class FileListValidator
 		}
 
 		return $files;
+	}
+
+	/**
+	 * Get the language direction - we want to be more lenient for rtl languages
+	 * @return string
+	 */
+	public function getDirection()
+	{
+		return $this->direction;
 	}
 }

--- a/src/Phpbb/TranslationValidator/Validator/FileValidator.php
+++ b/src/Phpbb/TranslationValidator/Validator/FileValidator.php
@@ -15,6 +15,8 @@ use Phpbb\TranslationValidator\Output\OutputInterface;
 class FileValidator
 {
 	/** @var string */
+	protected $direction;
+	/** @var string */
 	protected $originIso;
 	/** @var string */
 	protected $originPath;
@@ -38,6 +40,9 @@ class FileValidator
 	protected $input;
 	/** @var \Phpbb\TranslationValidator\Output\OutputInterface */
 	protected $output;
+
+	/** @var LangKeyValidator  */
+	protected $langKeyValidator;
 
 	/** @var array List from https://developers.google.com/recaptcha/docs/language */
 	private $reCaptchaLanguages = [
@@ -122,7 +127,19 @@ class FileValidator
 	{
 		$this->input = $input;
 		$this->output = $output;
-		$this->langkeyValidator = new LangKeyValidator($input, $output);
+		$this->langKeyValidator = new LangKeyValidator($input, $output);
+	}
+
+	/**
+	 * Set the language direction
+	 * @param $direction
+	 * @return $this
+	 */
+	public function setDirection($direction)
+	{
+		$this->direction = $direction;
+		$this->langKeyValidator->setDirection($direction);
+		return $this;
 	}
 
 	/**
@@ -138,7 +155,7 @@ class FileValidator
 		$this->originIso = $originIso;
 		$this->originPath = $originPath;
 		$this->originLanguagePath = $originLanguagePath;
-		$this->langkeyValidator->setOrigin($originIso, $originPath, $originLanguagePath);
+		$this->langKeyValidator->setOrigin($originIso, $originPath, $originLanguagePath);
 		return $this;
 	}
 
@@ -155,7 +172,7 @@ class FileValidator
 		$this->sourceIso = $sourceIso;
 		$this->sourcePath = $sourcePath;
 		$this->sourceLanguagePath = $sourceLanguagePath;
-		$this->langkeyValidator->setSource($sourceIso, $sourcePath, $sourceLanguagePath);
+		$this->langKeyValidator->setSource($sourceIso, $sourcePath, $sourceLanguagePath);
 		return $this;
 	}
 
@@ -168,7 +185,7 @@ class FileValidator
 	public function setPhpbbVersion($phpbbVersion)
 	{
 		$this->phpbbVersion = $phpbbVersion;
-		$this->langkeyValidator->setPhpbbVersion($phpbbVersion);
+		$this->langKeyValidator->setPhpbbVersion($phpbbVersion);
 		return $this;
 	}
 
@@ -181,7 +198,7 @@ class FileValidator
 	public function setPluralRule($pluralRule)
 	{
 		$this->pluralRule = $pluralRule;
-		$this->langkeyValidator->setPluralRule($pluralRule);
+		$this->langKeyValidator->setPluralRule($pluralRule);
 		return $this;
 	}
 
@@ -194,7 +211,7 @@ class FileValidator
 	public function setDebug($debug)
 	{
 		$this->debug = $debug;
-		$this->langkeyValidator->setDebug($debug);
+		$this->langKeyValidator->setDebug($debug);
 		return $this;
 	}
 
@@ -346,7 +363,7 @@ class FileValidator
 				continue;
 			}
 
-			$this->langkeyValidator->validate($originFile, $againstLangKey, $againstLanguage, $validate[$againstLangKey]);
+			$this->langKeyValidator->validate($originFile, $againstLangKey, $againstLanguage, $validate[$againstLangKey]);
 		}
 
 		foreach ($validate as $validateLangKey => $validateLanguage)
@@ -555,13 +572,13 @@ class FileValidator
 			if (isset($help[0]))
 			{
 				$compare = isset($against[$entry][0]) ? $against[$entry][0] : '';
-				$this->langkeyValidator->validate($originFile, $entry . '.0', $compare, $help[0]);
+				$this->langKeyValidator->validate($originFile, $entry . '.0', $compare, $help[0]);
 			}
 
 			if (isset($help[1]))
 			{
 				$compare = isset($against[$entry][1]) ? $against[$entry][1] : '';
-				$this->langkeyValidator->validate($originFile, $entry . '.1', $compare, $help[1]);
+				$this->langKeyValidator->validate($originFile, $entry . '.1', $compare, $help[1]);
 			}
 			$entry++;
 		}
@@ -817,7 +834,8 @@ class FileValidator
 		}
 		if (!empty($additionalRules))
 		{
-			$this->output->addMessage(Output::FATAL, 'Stylesheet file has additional CSS rules: ' . implode(', ', $additionalRules), $originFile);
+			$additionalRulesLevel = ($this->direction == 'rtl') ? Output::WARNING : Output::FATAL; // be more lenient for RTL
+			$this->output->addMessage($additionalRulesLevel, 'Stylesheet file has additional CSS rules: ' . implode(', ', $additionalRules), $originFile);
 		}
 	}
 

--- a/src/Phpbb/TranslationValidator/Validator/LangKeyValidator.php
+++ b/src/Phpbb/TranslationValidator/Validator/LangKeyValidator.php
@@ -16,6 +16,8 @@ use Phpbb\TranslationValidator\Output\OutputInterface;
 class LangKeyValidator
 {
 	/** @var string */
+	protected $direction;
+	/** @var string */
 	protected $originIso;
 	/** @var string */
 	protected $originPath;
@@ -59,6 +61,17 @@ class LangKeyValidator
 	{
 		$this->input = $input;
 		$this->output = $output;
+	}
+
+	/**
+	 * Set the language direction
+	 * @param $direction
+	 * @return $this
+	 */
+	public function setDirection($direction)
+	{
+		$this->direction = $direction;
+		return $this;
 	}
 
 	/**
@@ -775,6 +788,11 @@ class LangKeyValidator
 			preg_match('#^<a href="([a-zA-Z0-9_\:\&\/\?\.\-\#]+)" rel="external">$#', $html))
 		{
 			return Output::ERROR;
+		}
+
+		if ($this->direction == 'rtl' && (strpos($html, 'ltr') !== false || strpos($html, 'rtl') !== false))
+		{
+			return Output::WARNING; // be more lenient for RTL
 		}
 
 		return Output::FATAL;

--- a/src/Phpbb/TranslationValidator/Validator/ValidatorRunner.php
+++ b/src/Phpbb/TranslationValidator/Validator/ValidatorRunner.php
@@ -138,9 +138,9 @@ class ValidatorRunner
 	 */
 	public function runValidators()
 	{
-		$filelistValidator = new FileListValidator($this->input, $this->output);
+		$fileListValidator = new FileListValidator($this->input, $this->output);
 
-		$validateFiles = $filelistValidator->setSource($this->sourceIso, $this->sourcePath, $this->sourceLanguagePath)
+		$validateFiles = $fileListValidator->setSource($this->sourceIso, $this->sourcePath, $this->sourceLanguagePath)
 			->setOrigin($this->originIso, $this->originPath, $this->originLanguagePath)
 			->setPhpbbVersion($this->phpbbVersion)
 			->setDebug($this->debug)
@@ -164,9 +164,10 @@ class ValidatorRunner
 		$this->maxProgress = sizeof($validateFiles) + 1;
 		$this->progressLength = 11 + strlen($this->maxProgress) * 2;
 
-		$filelistValidator = new FileValidator($this->input, $this->output);
-		$filelistValidator->setSource($this->sourceIso, $this->sourcePath, $this->sourceLanguagePath)
+		$fileValidator = new FileValidator($this->input, $this->output);
+		$fileValidator->setSource($this->sourceIso, $this->sourcePath, $this->sourceLanguagePath)
 			->setOrigin($this->originIso, $this->originPath, $this->originLanguagePath)
+			->setDirection($fileListValidator->getDirection())
 			->setPhpbbVersion($this->phpbbVersion)
 			->setPluralRule($pluralRule)
 			->setDebug($this->debug)
@@ -176,7 +177,7 @@ class ValidatorRunner
 		{
 			$this->output->writelnIfDebug('');
 			$this->output->writelnIfDebug("Validating file: $originFile");
-			$filelistValidator->validate($sourceFile, $originFile);
+			$fileValidator->validate($sourceFile, $originFile);
 			$this->printErrorLevel($this->output);
 
 			usleep(31250);//125000);


### PR DESCRIPTION
Using Arabic and Persian as examples, some of the rules are more lenient now for right-to-left languages (#48):

* If there's additional HTML and it looks like it's to do with hard coding something to do with direction (check for `ltr` or `rtl` in the HTML) then downgrade to just a warning
* If it's an RTL language then be more lenient on stylesheets having additional CSS rules

Are you able to check this @Crizz0 and let me know if there's any other rules we should be more lenient for?